### PR TITLE
fix: update default API URL placeholder, closes CLD-5970

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ Compile / compile := ((Compile / compile) dependsOn (Compile / smithyBuild)).val
 Compile / packageBin / mappings := {
   val defaultMappings = (Compile / packageBin / mappings).value
   val smithyDirectory = (Compile / smithyOutputDir).value / "source" / "sources"
-  val smithyFiles = smithyDirectory ** "**" pair Path.rebase(smithyDirectory,  "META-INF/smithy")
+  val smithyFiles = smithyDirectory ** "**" pair Path.rebase(smithyDirectory, "META-INF/smithy")
   smithyFiles ++ defaultMappings
 }
 Compile / unmanagedSourceDirectories += sourceDirectory.value / "main" / "smithy"
@@ -28,9 +28,9 @@ lazy val openapi = (project in file("openapi"))
   .settings(
     Preprocess / sourceDirectory := sourceDirectory.value / "main" / "openapi",
     Preprocess / preprocessRules := Seq(
-      ("API_URL_PLACEHOLDER".r, _ => "https://cloud.gatling.io"),
+      ("API_URL_PLACEHOLDER".r, _ => "https://api.gatling.io"),
       ("VERSION_PLACEHOLDER".r, _ => version.value)
     ),
     Preprocess / preprocessIncludeFilter := "*.yaml",
-    Preprocess / target := target.value / "openapi",
+    Preprocess / target := target.value / "openapi"
   )


### PR DESCRIPTION
Modifications:

- Update the URL
- Fix misc formatting issue

Result:
The default URL with be api.gatling.io