### PR TITLE
fix: remove version stamp in header

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,7 @@ lazy val openapi = (project in file("openapi"))
   .settings(
     Preprocess / sourceDirectory := sourceDirectory.value / "main" / "openapi",
     Preprocess / preprocessRules := Seq(
-      ("API_URL_PLACEHOLDER".r, _ => "https://api.gatling.io"),
-      ("VERSION_PLACEHOLDER".r, _ => version.value)
+      ("API_URL_PLACEHOLDER".r, _ => "https://api.gatling.io")
     ),
     Preprocess / preprocessIncludeFilter := "*.yaml",
     Preprocess / target := target.value / "openapi"

--- a/openapi/src/main/openapi/openapi.yaml
+++ b/openapi/src/main/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Gatling Enterprise Cloud API
   description: Documentation of the public Gatling Enterprise Cloud API. To use this API you will need to generate an API token.
-  version: 'VERSION_PLACEHOLDER'
+  version: ''
 servers:
   - url: '{API_URL}/api/public'
     variables:


### PR DESCRIPTION
Motivation:
The version of the API documentation is useless and confusing

Modifications:

- Remove the displayed version stamp

Result:
No more version stamp displayed