### PR TITLE
chore: update API definitions for stop criteria, closes CLD-5906

### DIFF
--- a/openapi/src/main/openapi/common/components.yaml
+++ b/openapi/src/main/openapi/common/components.yaml
@@ -68,6 +68,104 @@ schemas:
     example:
       customProperty: "value"
 
+  StopCriteria:
+    type: array
+    description: An array of stop criteria that includes CPU, error ratio, and response time configurations.
+      This is particularly useful for terminating test runs once key performance metrics exceed acceptable limits.
+    items:
+      oneOf:
+        - $ref: '#/schemas/MeanCpuStopCriterion'
+        - $ref: '#/schemas/GlobalErrorRatioStopCriterion'
+        - $ref: '#/schemas/GlobalResponseTimeStopCriterion'
+
+  MeanCpuStopCriterion:
+    type: object
+    description: Stop criterion based on CPU usage
+    required:
+      - type
+      - threshold
+      - timeframeInSeconds
+    properties:
+      type:
+        type: string
+        enum:
+          - meanCpu
+        description: Type of the stop criterion.
+      threshold:
+        $ref: '#/schemas/MeanCpuThreshold'
+      timeframeInSeconds:
+        type: integer
+        description: Timeframe in seconds to measure the stop criterion.
+        example: 60
+
+  GlobalErrorRatioStopCriterion:
+    type: object
+    description: Stop criterion based on global error ratio
+    required:
+      - type
+      - threshold
+      - timeframeInSeconds
+    properties:
+      type:
+        type: string
+        enum:
+          - globalErrorRatio
+        description: Type of the stop criterion.
+      threshold:
+        $ref: '#/schemas/GlobalErrorRatioThreshold'
+      timeframeInSeconds:
+        type: integer
+        description: Timeframe in seconds to measure the stop criterion.
+        example: 60
+
+  GlobalResponseTimeStopCriterion:
+    type: object
+    description: Stop criterion based on global response time
+    required:
+      - type
+      - threshold
+      - timeframeInSeconds
+    properties:
+      type:
+        type: string
+        enum:
+          - globalResponseTime
+        description: Type of the stop criterion.
+      threshold:
+        $ref: '#/schemas/GlobalResponseTimeThreshold'
+      timeframeInSeconds:
+        type: integer
+        description: Timeframe in seconds to measure the stop criterion.
+        example: 100
+
+  MeanCpuThreshold:
+    type: object
+    properties:
+      maxPercentage:
+        type: number
+        description: The maximum allowed CPU percentage.
+        example: 90
+
+  GlobalErrorRatioThreshold:
+    type: object
+    properties:
+      maxPercentage:
+        type: number
+        description: The maximum allowed error ratio percentage.
+        example: 90
+
+  GlobalResponseTimeThreshold:
+    type: object
+    properties:
+      percentile:
+        type: number
+        description: The percentile for response time threshold.
+        example: 99.9
+      maxMilliseconds:
+        type: number
+        description: The maximum allowed response time in milliseconds.
+        example: 300
+
 # Examples
 examples:
 

--- a/openapi/src/main/openapi/openapi.yaml
+++ b/openapi/src/main/openapi/openapi.yaml
@@ -14,16 +14,19 @@ components:
       type: apiKey
       in: header
       name: authorization
+  schemas:
+    CommonSchema:
+      $ref: 'common/components.yaml#/schemas'
 paths:
   # Default
   /ping:
     $ref: 'default/path.yaml#/ping'
 
   # Simulation
-  /simulations:
-    $ref: 'simulation/path.yaml#/simulations'
   /simulations/{simulationId}:
     $ref: 'simulation/path.yaml#/simulations.one'
+  /simulations: # Cannot be first, otherwise Swagger UI reference resolution show errors when resolving array reference of simulations
+    $ref: 'simulation/path.yaml#/simulations'
   /simulations/{simulationId}/classname:
     $ref: 'simulation/path.yaml#/simulations.one.classname'
   /simulations/team:

--- a/openapi/src/main/openapi/runs/components.yaml
+++ b/openapi/src/main/openapi/runs/components.yaml
@@ -123,6 +123,8 @@ schemas:
                       type: string
           artifactId:
             type: string
+          stopCriteria:
+            $ref: '../common/components.yaml#/schemas/StopCriteria'
       comments:
         type: object
         properties:

--- a/openapi/src/main/openapi/simulation/components.yaml
+++ b/openapi/src/main/openapi/simulation/components.yaml
@@ -94,6 +94,8 @@ requests:
               type: boolean
               description: Use dedicated IPs for your load generators
               example: false
+            stopCriteria:
+                $ref: '../common/components.yaml#/schemas/StopCriteria'
 
   # TODO: all requests should be defined here
 
@@ -177,6 +179,8 @@ responses:
         type: boolean
         description: Use dedicated IPs for your load generators
         example: false
+      stopCriteria:
+        $ref: '../common/components.yaml#/schemas/StopCriteria'
 
   # TODO: all responses should be defined here
 
@@ -210,6 +214,8 @@ schemas:
         description: Fully qualified class name of a simulation
         example: computerdatabase.BasicSimulation
 
+  StopCriterion:
+    type: object
 
   HostsByPool:
     type: object


### PR DESCRIPTION
Modifications:
* Add stop criteria in simulation request and response
* Add stop criteria in run snapshot