### PR TITLE
fix: align upload API definition with implementation

### DIFF
--- a/openapi/src/main/openapi/pkgs/components.yaml
+++ b/openapi/src/main/openapi/pkgs/components.yaml
@@ -118,3 +118,24 @@ responses:
         example: "424571fe-2351-4f3f-ae6a-04b7105f7157"
       file:
         $ref: "#/responses/PackageFile"
+
+  PackageUpload:
+    type: object
+    description: Package that have been uploaded
+    required:
+      - id
+      - filename
+      - contentLength
+    properties:
+      id:
+        type: string
+        description: Package ID
+        example: "0164293d-d15a-465f-8f40-41a2133fb35e"
+      filename:
+        type: string
+        description: Name of the uploaded file
+        example: "maven-sample-1.0.0-shaded.jar"
+      contentLength:
+        type: number
+        description: Content length of the uploaded file in bytes
+        example: "15000"

--- a/openapi/src/main/openapi/pkgs/path.yaml
+++ b/openapi/src/main/openapi/pkgs/path.yaml
@@ -25,7 +25,7 @@ packages.upload:
         content:
           application/json:
             schema:
-              $ref: 'components.yaml#/responses/Package'
+              $ref: 'components.yaml#/responses/PackageUpload'
       '413':
         description: Uploaded package is too large
 


### PR DESCRIPTION
See: https://github.com/gatling/frontline-cloud/blob/dev/back/adapters/webapp/src/main/scala/io/gatling/enterprise/adapter/webapp/route/external/model/responses/pkg/PkgUpload.scala#L19